### PR TITLE
Allow to customize the address classeur listens to

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,8 @@ app.use('/assets', serveStatic(path.join(path.dirname(require.resolve('classets/
 app.use(serveStatic(path.join(__dirname, 'public')));
 
 var port = process.env.PORT || 11583;
-http.createServer(app).listen(port, function() {
-	console.log('Server started http://localhost:' + port);
+var addr = process.env.BINDING_ADDR || 'localhost';
+http.createServer(app).listen(port, host, function() {
+	console.log('Server started http://' + addr + ':' + port);
 });
 


### PR DESCRIPTION
The behavior of listen is a little queer, especially in regard of binding to an IPv6 socket. Some OS consider such socket to be listening both for IPv4 or IPv6, other OS have IPv6 sockets listening only to IPv6, and not to IPv4.

This change introduces a BINDING_ADDR environment variable to alllow to customize listening address.
If omitted, it binds to localhost instead.

Reference: https://nodejs.org/api/http.html#http_server_listen_port_hostname_backlog_callback
