### PR TITLE
Fixed Blogger example URL.

### DIFF
--- a/src/blogs/blogger/bloggerBlogForm.html
+++ b/src/blogs/blogger/bloggerBlogForm.html
@@ -3,5 +3,5 @@
   <input autocomplete="off" ng-model="form.subForm.blogUrl">
 </md-input-container>
 <p class="tip">
-  <b>Example:</b> http://example.blogger.com/
+  <b>Example:</b> https://example.blogspot.com/
 </p>


### PR DESCRIPTION
Using `blogger.com` to link will result in error.

Also uses HTTPS as it's always supported on blogspot.com.